### PR TITLE
refactor(resource-graph): reorganize StageResponsible type and clean …

### DIFF
--- a/modules/cache/keys/query-keys.ts
+++ b/modules/cache/keys/query-keys.ts
@@ -303,6 +303,9 @@ export const queryKeys = {
     infinite: (filters?: Record<string, unknown>) => [...queryKeys.kanban.list(filters), 'infinite'] as const,
     details: () => [...queryKeys.kanban.all, 'detail'] as const,
     detail: (id: string) => [...queryKeys.kanban.details(), id] as const,
+  },
+
+  // -------------------------------------------------------------------------
   // Section Statuses (статусы разделов)
   // -------------------------------------------------------------------------
   sectionStatuses: {

--- a/modules/resource-graph/actions/index.ts
+++ b/modules/resource-graph/actions/index.ts
@@ -18,6 +18,7 @@ import type {
   Loading,
   ReadinessPoint,
   ProjectReport,
+  StageResponsible,
 } from '../types'
 import { transformRowsToHierarchy, transformProfileToCreatedBy } from '../utils'
 import type { FilterQueryParams } from '@/modules/inline-filter'
@@ -1296,15 +1297,13 @@ export async function deleteStageReport(
     return {
       success: false,
       error: error instanceof Error ? error.message : 'Ошибка удаления отчета',
+    }
+  }
+}
+
+// ============================================================================
 // Stage Responsibles Actions - Ответственные за этапы
 // ============================================================================
-
-export interface StageResponsible {
-  id: string
-  firstName: string | null
-  lastName: string | null
-  avatarUrl: string | null
-}
 
 /**
  * Получить ответственных за этапы раздела

--- a/modules/resource-graph/components/timeline/rows/DecompositionStageRow.tsx
+++ b/modules/resource-graph/components/timeline/rows/DecompositionStageRow.tsx
@@ -18,8 +18,8 @@ import type {
   WorkLog,
   Loading,
   ReadinessPoint,
+  StageResponsible,
 } from '../../../types'
-import type { StageResponsible } from '../../../actions'
 import type { DayCell } from '../TimelineHeader'
 import { TimelineGrid, ProgressCircle, PeriodBackground } from '../shared'
 import { LoadingBars, calculateLoadingsRowHeight, LOADING_DRAG_TYPE, type LoadingDragData } from '../LoadingBars'

--- a/modules/resource-graph/hooks/index.ts
+++ b/modules/resource-graph/hooks/index.ts
@@ -37,8 +37,6 @@ import {
   deleteLoading as deleteLoadingAction,
 } from '../actions'
 
-import type { StageResponsible } from '../actions'
-
 import type {
   Project,
   ProjectTag,
@@ -47,6 +45,7 @@ import type {
   Loading,
   ReadinessPoint,
   ProjectReport,
+  StageResponsible,
 } from '../types'
 
 import {

--- a/modules/resource-graph/types/index.ts
+++ b/modules/resource-graph/types/index.ts
@@ -399,3 +399,15 @@ export interface ProjectStructure {
   objects: Array<{ id: string; name: string; stageId: string | null }>
   sections: Array<{ id: string; name: string; objectId: string | null }>
 }
+
+// ============================================================================
+// Stage Responsibles Types - Ответственные за этапы
+// ============================================================================
+
+/** Ответственный за этап декомпозиции */
+export interface StageResponsible {
+  id: string
+  firstName: string | null
+  lastName: string | null
+  avatarUrl: string | null
+}

--- a/modules/resource-graph/utils/index.ts
+++ b/modules/resource-graph/utils/index.ts
@@ -516,19 +516,6 @@ export function getEmployeeColor(employeeId: string | null): string {
   return EMPLOYEE_COLORS[index]
 }
 
-/**
- * Получить инициалы из имени и фамилии
- *
- * @param firstName - Имя
- * @param lastName - Фамилия
- * @returns Инициалы (1-2 буквы)
- */
-export function getInitials(firstName: string | null, lastName: string | null): string {
-  const first = firstName?.charAt(0)?.toUpperCase() || ''
-  const last = lastName?.charAt(0)?.toUpperCase() || ''
-  return first + last || '?'
-}
-
 // ============================================================================
 // Profile Transformation
 // ============================================================================


### PR DESCRIPTION
…up imports

- Moved StageResponsible interface definition to types/index.ts for better organization.
- Removed duplicate imports of StageResponsible in various files.
- Cleaned up unused code related to getting initials from names in utils/index.ts.